### PR TITLE
chore: Change the raw_link & ping repository owner

### DIFF
--- a/info.json
+++ b/info.json
@@ -15,7 +15,7 @@
     "live_update": true,
     "name": "AdBlockID_git_realodix",
     "own_management": false,
-    "ping": [],
+    "ping": ["@realodix"],
     "raw_link": "https://raw.githubusercontent.com/realodix/AdBlockID/master/tools/dead-hosts/dead-hosts--AdBlockID_git_realodix.txt",
     "start_datetime": "2020-02-21T15:48:07.274022",
     "start_timestamp": 1582300087.274022

--- a/info.json
+++ b/info.json
@@ -16,7 +16,7 @@
     "name": "AdBlockID_git_realodix",
     "own_management": false,
     "ping": [],
-    "raw_link": "https://raw.githubusercontent.com/realodix/AdBlockID/master/output/adblockid.txt",
+    "raw_link": "https://raw.githubusercontent.com/realodix/AdBlockID/master/tools/dead-hosts/dead-hosts--AdBlockID_git_realodix.txt",
     "start_datetime": "2020-02-21T15:48:07.274022",
     "start_timestamp": 1582300087.274022
 }


### PR DESCRIPTION
**List of changes**
- New raw_link is https://raw.githubusercontent.com/realodix/AdBlockID/master/tools/dead-hosts/dead-hosts--AdBlockID_git_realodix.txt
- Ping repository owner once a new test is finished.